### PR TITLE
corrección 02-selectors selector por class

### DIFF
--- a/04-social-network/02-jquery/02-selectors/README.md
+++ b/04-social-network/02-jquery/02-selectors/README.md
@@ -39,7 +39,7 @@ Ejemplos:
   ```javascript
   $('.dogs');
   $('.cats');
-  $('.pink', '.blue', '.red');
+  $('.pink .blue .red');
   ```
 
 > **Nota:** Todos los selectores de jQuery comienzan con el signo de dólar y


### PR DESCRIPTION
Corrección en la línea 42, para acceder a varias clases se escriben todas dentro de la mismas comillas y no por separado

`$('.pink .blue .red');` en vez de `$('.pink', '.blue', '.red');`