### PR TITLE
project(cipher): Prevenir a Mocha de mostrar errores de stdout cuando los tests fallan

### DIFF
--- a/projects/01-cipher/package.json
+++ b/projects/01-cipher/package.json
@@ -9,7 +9,7 @@
     "pretest": "npm run eslint && npm run htmlhint",
     "test-browser": "opener ./test/index.html",
     "test-node": "nyc mocha ./test/headless.js",
-    "test": "npm run test-node && npm run test-browser"
+    "test": "npm run test-node --silent && npm run test-browser"
   },
   "dependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
Para el proyecto Cipher, si los tests fallaran al final del output vemos lo siguiente:
<img width="709" alt="screen shot 2019-01-15 at 11 24 07" src="https://user-images.githubusercontent.com/45951334/51198550-29749280-18ba-11e9-9699-1a1c7cff6ba1.png">

Este PR agrega el flag `--silent`[[1]] al comando npm run que usamos para correr los tests, de esa manera el output será:
<img width="366" alt="screen shot 2019-01-15 at 11 25 46" src="https://user-images.githubusercontent.com/45951334/51198639-6fc9f180-18ba-11e9-8118-0c7137d8792f.png">

Esto puede ayudar a las estudiantes en enfocarse en los demás contenidos del log que sí indican que tests siguen fallando. Y esconde un texto que las puede confundir.

Mocha tiene ese comportamiento por defecto y es usado cuando se trabaja con servidores y CIs, no siendo el caso para este proyecto.

Conversación sobre un silent flag para mocha: https://github.com/mochajs/mocha/issues/138

[1]: https://docs.npmjs.com/misc/config#loglevel