### PR TITLE
Eliminando niveles esperados en readme de proyectos

### DIFF
--- a/projects/03-social-network/README.md
+++ b/projects/03-social-network/README.md
@@ -280,7 +280,7 @@ evaluaremos cuando lo  completes:
 
 ### General
 
-| Característica 
+| Característica
 |----------------
 | Completitud
 
@@ -289,7 +289,7 @@ evaluaremos cuando lo  completes:
 Para este proyecto esperamos que ya hayas alcanzado el nivel 3 en todas tus
 habilidades blandas. Te aconsejamos revisar la rúbrica:
 
-| Habilidad                    
+| Habilidad
 |------------------------------
 | **Autogestión**
 | Planificación y organización
@@ -305,7 +305,7 @@ habilidades blandas. Te aconsejamos revisar la rúbrica:
 
 ### Tech
 
-| Habilidad              
+| Habilidad
 |------------------------
 | **CS**
 | Lógica

--- a/projects/03-social-network/README.md
+++ b/projects/03-social-network/README.md
@@ -280,59 +280,59 @@ evaluaremos cuando lo  completes:
 
 ### General
 
-| Característica | Nivel esperado |
-|----------------|----------------|
-| Completitud    | 4              |
+| Característica 
+|----------------
+| Completitud
 
 ### Habilidades Blandas
 
 Para este proyecto esperamos que ya hayas alcanzado el nivel 3 en todas tus
 habilidades blandas. Te aconsejamos revisar la rúbrica:
 
-| Habilidad                    | Nivel esperado |
-|------------------------------|----------------|
-| **Autogestión**                               |
-| Planificación y organización | 3              |
-| Autoaprendizaje              | 3              |
-| Presentaciones               | 3              |
-| Adaptabilidad                | 3              |
-| Solución de problemas        | 3              |
-| **Relaciones interpersonales**                |
-| Trabajo en equipo            | 3              |
-| Responsabilidad              | 3              |
-| Dar y recibir feedback       | 3              |
-| Comunicación eficaz          | 3              |
+| Habilidad                    
+|------------------------------
+| **Autogestión**
+| Planificación y organización
+| Autoaprendizaje
+| Presentaciones
+| Adaptabilidad
+| Solución de problemas
+| **Relaciones interpersonales**
+| Trabajo en equipo
+| Responsabilidad
+| Dar y recibir feedback
+| Comunicación eficaz
 
 ### Tech
 
-| Habilidad              | Nivel esperado |
-|------------------------|----------------|
-| **CS**                                  |
-| Lógica                 | 2              |
-| Arquitectura           | 2              |
-| **SCM**                                 |
-| Git                    | 3              |
-| GitHub                 | 3              |
-| **JavaScript**                          |
-| Estilo                 | 3              |
-| Nomenclatura/semántica | 3              |
-| Funciones/modularidad  | 2              |
-| Estructuras de datos   | 2              |
-| Tests                  | 2              |
-| **HTML**                                |
-| Validación             | 3              |
-| Estilo                 | 3              |
-| Semántica              | 3              |
-| **CSS**                                 |
-| DRY                    | 3              |
-| Responsive             | 3              |
+| Habilidad              
+|------------------------
+| **CS**
+| Lógica
+| Arquitectura
+| **SCM**
+| Git
+| GitHub
+| **JavaScript**
+| Estilo
+| Nomenclatura/semántica
+| Funciones/modularidad
+| Estructuras de datos
+| Tests
+| **HTML**
+| Validación
+| Estilo
+| Semántica
+| **CSS**
+| DRY
+| Responsive
 
 ### UX
 
-| Habilidad       | Nivel esperado |
-|-----------------|----------------|
-| User Centricity | 3              |
-| Visual Design   | 2              |
+| Habilidad
+|-----------------
+| User Centricity
+| Visual Design
 
 ***
 

--- a/projects/04-burger-queen/README.md
+++ b/projects/04-burger-queen/README.md
@@ -228,9 +228,9 @@ evaluaremos cuando lo  completes:
 
 ### General
 
-| Característica 
+| Característica
 |----------------
-| Completitud    
+| Completitud
 
 ### Habilidades Blandas
 
@@ -252,7 +252,7 @@ habilidades blandas. Te aconsejamos revisar la rúbrica:
 
 ### Tech
 
-| Habilidad              
+| Habilidad
 |------------------------
 | **CS**
 | Lógica

--- a/projects/04-burger-queen/README.md
+++ b/projects/04-burger-queen/README.md
@@ -228,59 +228,59 @@ evaluaremos cuando lo  completes:
 
 ### General
 
-| Característica | Nivel esperado |
-|----------------|----------------|
-| Completitud    | 4              |
+| Característica 
+|----------------
+| Completitud    
 
 ### Habilidades Blandas
 
 Para este proyecto esperamos que ya hayas alcanzado el nivel 4 en todas tus
 habilidades blandas. Te aconsejamos revisar la rúbrica:
 
-| Habilidad                    | Nivel esperado |
-|------------------------------|----------------|
-| **Autogestión**                               |
-| Planificación y organización | 4              |
-| Autoaprendizaje              | 4              |
-| Presentaciones               | 4              |
-| Adaptabilidad                | 4              |
-| Solución de problemas        | 4              |
-| **Relaciones interpersonales**                |
-| Responsabilidad              | 4              |
-| Dar y recibir feedback       | 4              |
-| Comunicación eficaz          | 4              |
+| Habilidad
+|------------------------------
+| **Autogestión**
+| Planificación y organización
+| Autoaprendizaje
+| Presentaciones
+| Adaptabilidad
+| Solución de problemas
+| **Relaciones interpersonales**
+| Responsabilidad
+| Dar y recibir feedback
+| Comunicación eficaz
 
 ### Tech
 
-| Habilidad              | Nivel esperado |
-|------------------------|----------------|
-| **CS**                                  |
-| Lógica                 | 2              |
-| Arquitectura           | 3              |
-| Patrones/Paradigmas    | 2              |
-| **SCM**                                 |
-| Git                    | 3              |
-| GitHub                 | 3              |
-| **JavaScript**                          |
-| Estilo                 | 3              |
-| Nomenclatura/semántica | 3              |
-| Funciones/modularidad  | 4              |
-| Estructuras de datos   | 3              |
-| Tests                  | 3              |
-| **HTML**                                |
-| Validación             | 3              |
-| Estilo                 | 3              |
-| Semántica              | 4              |
-| **CSS**                                 |
-| DRY                    | 4              |
-| Responsive             | 4              |
+| Habilidad              
+|------------------------
+| **CS**
+| Lógica
+| Arquitectura
+| Patrones/Paradigmas
+| **SCM**
+| Git
+| GitHub
+| **JavaScript**
+| Estilo
+| Nomenclatura/semántica
+| Funciones/modularidad
+| Estructuras de datos
+| Tests
+| **HTML**
+| Validación
+| Estilo
+| Semántica
+| **CSS**
+| DRY
+| Responsive
 
 ### UX
 
-| Habilidad       | Nivel esperado |
-|-----------------|----------------|
-| User Centricity | 3              |
-| Visual Design   | 2              |
+| Habilidad
+|-----------------
+| User Centricity
+| Visual Design
 
 ## Primeros pasos
 

--- a/projects/04-md-links/README.md
+++ b/projects/04-md-links/README.md
@@ -233,44 +233,44 @@ evaluaremos cuando lo  completes:
 
 ### General
 
-| Característica | Nivel esperado |
-|----------------|----------------|
-| Completitud    | 4              |
+| Característica
+|----------------
+| Completitud
 
 ### Habilidades Blandas
 
 Para este proyecto esperamos que ya hayas alcanzado el nivel 4 en todas tus
 habilidades blandas. Te aconsejamos revisar la rúbrica:
 
-| Habilidad                    | Nivel esperado |
-|------------------------------|----------------|
-| **Autogestión**                               |
-| Planificación y organización | 4              |
-| Autoaprendizaje              | 4              |
-| Presentaciones               | 4              |
-| Adaptabilidad                | 4              |
-| Solución de problemas        | 4              |
-| **Relaciones interpersonales**                |
-| Responsabilidad              | 4              |
-| Dar y recibir feedback       | 4              |
-| Comunicación eficaz          | 4              |
+| Habilidad
+|------------------------------
+| **Autogestión**
+| Planificación y organización
+| Autoaprendizaje
+| Presentaciones
+| Adaptabilidad
+| Solución de problemas
+| **Relaciones interpersonales**
+| Responsabilidad
+| Dar y recibir feedback
+| Comunicación eficaz
 
 ### Tech
 
-| Habilidad              | Nivel esperado |
-| ---------------------- | -------------- |
-| **CS**                 |                |
-| Lógica                 | 2              |
-| Arquitectura           | 3              |
-| **SCM**                |                |
-| Git                    | 3              |
-| GitHub                 | 3              |
-| **JavaScript**         |                |
-| Estilo                 | 3              |
-| Nomenclatura/semántica | 3              |
-| Funciones/modularidad  | 4              |
-| Estructuras de datos   | 3              |
-| Tests                  | 3              |
+| Habilidad
+| ---------------------- 
+| **CS**
+| Lógica
+| Arquitectura
+| **SCM**
+| Git
+| GitHub
+| **JavaScript**
+| Estilo
+| Nomenclatura/semántica
+| Funciones/modularidad
+| Estructuras de datos
+| Tests
 
 ## Pistas / Tips
 

--- a/projects/04-md-links/README.md
+++ b/projects/04-md-links/README.md
@@ -258,7 +258,7 @@ habilidades blandas. Te aconsejamos revisar la rúbrica:
 ### Tech
 
 | Habilidad
-| ---------------------- 
+| ----------------------
 | **CS**
 | Lógica
 | Arquitectura

--- a/projects/04-social-network-frameworks/README.md
+++ b/projects/04-social-network-frameworks/README.md
@@ -87,9 +87,9 @@ evaluaremos cuando lo  completes:
 
 ### General
 
-| Característica | Nivel esperado |
-|----------------|----------------|
-| Completitud    | 4              |
+| Característica
+|----------------
+| Completitud
 
 ### Habilidades Blandas
 
@@ -107,44 +107,44 @@ la [guia general para organizar, dividir y planificar tu ttrabajo](https://docs.
 
 Te aconsejamos revisar la rúbrica:
 
-| Habilidad                    | Nivel esperado |
-|------------------------------|----------------|
-| **Autogestión**                               |
-| Planificación y organización | 4              |
-| Autoaprendizaje              | 4              |
-| Presentaciones               | 4              |
-| Adaptabilidad                | 4              |
-| Solución de problemas        | 4              |
-| **Relaciones interpersonales**                |
-| Trabajo en equipo            | 4              |
-| Responsabilidad              | 4              |
-| Dar y recibir feedback       | 4              |
-| Comunicación eficaz          | 4              |
+| Habilidad
+|------------------------------
+| **Autogestión**
+| Planificación y organización
+| Autoaprendizaje
+| Presentaciones
+| Adaptabilidad
+| Solución de problemas
+| **Relaciones interpersonales**
+| Trabajo en equipo
+| Responsabilidad
+| Dar y recibir feedback
+| Comunicación eficaz
 
 ### Tech
 
-| Habilidad              | Nivel esperado |
-|------------------------|----------------|
-| **CS**                                  |
-| Lógica                 | 2              |
-| Arquitectura           | 3              |
-| Patrones/Paradigmas    | 2              |
-| **SCM**                                 |
-| Git                    | 3              |
-| GitHub                 | 3              |
-| **JavaScript**                          |
-| Estilo                 | 3              |
-| Nomenclatura/semántica | 3              |
-| Funciones/modularidad  | 4              |
-| Estructuras de datos   | 3              |
-| Tests                  | 3              |
-| **HTML**                                |
-| Validación             | 3              |
-| Estilo                 | 3              |
-| Semántica              | 4              |
-| **CSS**                                 |
-| DRY                    | 4              |
-| Responsive             | 4              |
+| Habilidad
+|------------------------
+| **CS**
+| Lógica
+| Arquitectura
+| Patrones/Paradigmas
+| **SCM**
+| Git
+| GitHub
+| **JavaScript**
+| Estilo
+| Nomenclatura/semántica
+| Funciones/modularidad
+| Estructuras de datos
+| Tests
+| **HTML**
+| Validación
+| Estilo
+| Semántica
+| **CSS**
+| DRY
+| Responsive
 
 ***
 

--- a/projects/05-bq-node/README.md
+++ b/projects/05-bq-node/README.md
@@ -246,41 +246,41 @@ evaluaremos cuando lo  completes:
 
 ### General
 
-| Característica | Nivel esperado |
-|----------------|----------------|
-| Completitud    | 4              |
+| Característica
+|----------------
+| Completitud
 
 ### Habilidades Blandas
 
-| Habilidad                    | Nivel esperado |
-|------------------------------|----------------|
-| **Autogestión**                               |
-| Planificación y organización | 4              |
-| Autoaprendizaje              | 4              |
-| Presentaciones               | 4              |
-| Adaptabilidad                | 4              |
-| Solución de problemas        | 4              |
-| **Relaciones interpersonales**                |
-| Responsabilidad              | 4              |
-| Dar y recibir feedback       | 4              |
-| Comunicación eficaz          | 4              |
+| Habilidad
+|------------------------------
+| **Autogestión**
+| Planificación y organización
+| Autoaprendizaje
+| Presentaciones
+| Adaptabilidad
+| Solución de problemas
+| **Relaciones interpersonales**
+| Responsabilidad
+| Dar y recibir feedback
+| Comunicación eficaz
 
 ### Tech
 
-| Habilidad              | Nivel esperado |
-| ---------------------- | -------------- |
-| **CS**                 |                |
-| Lógica                 | 2              |
-| Arquitectura           | 3              |
-| **SCM**                |                |
-| Git                    | 3              |
-| GitHub                 | 3              |
-| **JavaScript**         |                |
-| Estilo                 | 3              |
-| Nomenclatura/semántica | 3              |
-| Funciones/modularidad  | 4              |
-| Estructuras de datos   | 3              |
-| Tests                  | 3              |
+| Habilidad
+| ----------------------
+| **CS**
+| Lógica
+| Arquitectura
+| **SCM**
+| Git
+| GitHub
+| **JavaScript**
+| Estilo
+| Nomenclatura/semántica
+| Funciones/modularidad
+| Estructuras de datos
+| Tests
 
 ***
 

--- a/projects/05-tic-tac-toe-rn/README.md
+++ b/projects/05-tic-tac-toe-rn/README.md
@@ -90,41 +90,41 @@ evaluaremos cuando lo  completes:
 
 ### General
 
-| Característica | Nivel esperado |
-|----------------|----------------|
-| Completitud    | 4              |
+| Característica
+|----------------
+| Completitud
 
 ### Habilidades Blandas
 
-| Habilidad                    | Nivel esperado |
-|------------------------------|----------------|
-| **Autogestión**                               |
-| Planificación y organización | 4              |
-| Autoaprendizaje              | 4              |
-| Presentaciones               | 4              |
-| Adaptabilidad                | 4              |
-| Solución de problemas        | 4              |
-| **Relaciones interpersonales**                |
-| Responsabilidad              | 4              |
-| Dar y recibir feedback       | 4              |
-| Comunicación eficaz          | 4              |
+| Habilidad
+|------------------------------
+| **Autogestión**
+| Planificación y organización
+| Autoaprendizaje
+| Presentaciones
+| Adaptabilidad
+| Solución de problemas
+| **Relaciones interpersonales**
+| Responsabilidad
+| Dar y recibir feedback
+| Comunicación eficaz
 
 ### Tech
 
-| Habilidad              | Nivel esperado |
-| ---------------------- | -------------- |
-| **CS**                 |                |
-| Lógica                 | 2              |
-| Arquitectura           | 3              |
-| **SCM**                |                |
-| Git                    | 3              |
-| GitHub                 | 3              |
-| **JavaScript**         |                |
-| Estilo                 | 3              |
-| Nomenclatura/semántica | 3              |
-| Funciones/modularidad  | 4              |
-| Estructuras de datos   | 3              |
-| Tests                  | 3              |
+| Habilidad
+| ---------------------- 
+| **CS**
+| Lógica
+| Arquitectura
+| **SCM**
+| Git
+| GitHub
+| **JavaScript**
+| Estilo
+| Nomenclatura/semántica
+| Funciones/modularidad
+| Estructuras de datos
+| Tests
 
 ***
 

--- a/projects/05-tic-tac-toe-rn/README.md
+++ b/projects/05-tic-tac-toe-rn/README.md
@@ -112,7 +112,7 @@ evaluaremos cuando lo  completes:
 ### Tech
 
 | Habilidad
-| ---------------------- 
+| ----------------------
 | **CS**
 | Lógica
 | Arquitectura


### PR DESCRIPTION
Ya no aplican niveles esperados por proyecto, ahora son niveles esperados para final de CC y BC

**Proyectos modificados este item (solo readme)**

- 03-social-network
- 04-burguer-queen
- 04-md-links
- 04-social-network-frameworks
- 05-bq-node
- 05-tic-tac-toe-rn

@lupomontero @diegovelezg @CaroLaboratoria 